### PR TITLE
Fix `azurerm_storage_share`'s unauthorized error

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,6 +19,10 @@ provider "azurerm" {
   # ...
 }
 
+module "get_client_ip" {
+  source = "./modules/get_client_ip"
+}
+
 module "get_function_package_url" {
   source = "./modules/get_function_package_url"
 
@@ -39,4 +43,5 @@ module "function_cosmosdb_via_vnet" {
   resource_group_name  = var.resource_group_name
   app_identifier       = "${var.app_identifier}-via-vnet"
   function_package_url = module.get_function_package_url.download_url
+  client_ip            = module.get_client_ip.client_ip
 }

--- a/terraform/modules/function_cosmosdb_via_vnet/function.tf
+++ b/terraform/modules/function_cosmosdb_via_vnet/function.tf
@@ -68,17 +68,10 @@ resource "azurerm_storage_account_network_rules" "for_func" {
 
   default_action             = "Deny"
   virtual_network_subnet_ids = [azurerm_subnet.main.id]
+  ip_rules                   = [var.client_ip]
 }
 
 resource "azurerm_storage_share" "for_func" {
   name                 = local.function_name
   storage_account_name = azurerm_storage_account.for_func.name
-
-  acl {
-    id = data.azurerm_client_config.current.object_id
-
-    access_policy {
-      permissions = "rwdl"
-    }
-  }
 }

--- a/terraform/modules/function_cosmosdb_via_vnet/main.tf
+++ b/terraform/modules/function_cosmosdb_via_vnet/main.tf
@@ -1,5 +1,3 @@
-data "azurerm_client_config" "current" {}
-
 data "azurerm_resource_group" "main" {
   name = var.resource_group_name
 }

--- a/terraform/modules/function_cosmosdb_via_vnet/variables.tf
+++ b/terraform/modules/function_cosmosdb_via_vnet/variables.tf
@@ -9,3 +9,7 @@ variable "app_identifier" {
 variable "function_package_url" {
   type = string
 }
+
+variable "client_ip" {
+  type = string
+}

--- a/terraform/modules/get_client_ip/main.tf
+++ b/terraform/modules/get_client_ip/main.tf
@@ -1,0 +1,3 @@
+data "http" "get_client_ip" {
+  url = "https://ipinfo.io/json"
+}

--- a/terraform/modules/get_client_ip/outputs.tf
+++ b/terraform/modules/get_client_ip/outputs.tf
@@ -1,0 +1,3 @@
+output "client_ip" {
+  value = jsondecode(data.http.get_client_ip.body).ip
+}


### PR DESCRIPTION
I fixed the following error on `azurerm_storage_share`.

```
Error: shares.Client#GetProperties: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailure" Message="This request is not authorized to perform this operation.\nRequestId:3edbbf91-601a-005d-3a92-3a4909000000\nTime:2021-04-26T11:47:57.9895612Z"
```