### PR TITLE
Add dev container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version: bionic, focal
+ARG VARIANT="focal"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+RUN apt update && export DEBIAN_FRONTEND=noninteractive \
+  && apt install -y --no-install-recommends \
+    gnupg \
+    software-properties-common \
+    curl
+
+# Install Terraform CLI
+RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
+  && apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
+  && apt update && apt install -y --no-install-recommends \
+    terraform
+
+# Install Azure CLI
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/ubuntu
+{
+	"name": "Ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Ubuntu version: focal, bionic
+		"args": { "VARIANT": "focal" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
GitHub Codespaces にて起動し、`terraform` 及び `az` コマンドのインストールを確認済み。

```
vscode ➜ /workspaces/terraform-with-azure-bootcamp (dzeyelid/issue5 ✗) $ terraform -v
Terraform v1.0.5
on linux_amd64
vscode ➜ /workspaces/terraform-with-azure-bootcamp (dzeyelid/issue5 ✗) $ az -v
azure-cli                         2.27.1

core                              2.27.1
telemetry                          1.0.6

Python location '/opt/az/bin/python3'
Extensions directory '/home/vscode/.azure/cliextensions'

Python (Linux) 3.6.10 (default, Aug 11 2021, 02:41:08) 
[GCC 9.3.0]

Legal docs and information: aka.ms/AzureCliLegal


Your CLI is up-to-date.
```

resolves #5