### PR TITLE
Remove the `WEBSITE_CONTENTSHARE` from app settings

### DIFF
--- a/terraform/modules/function_cosmosdb_basic/function.tf
+++ b/terraform/modules/function_cosmosdb_basic/function.tf
@@ -27,7 +27,6 @@ resource "azurerm_function_app" "main" {
   app_settings = {
     AzureWebJobsStorage                      = azurerm_storage_account.for_func.primary_connection_string
     WEBSITE_CONTENTAZUREFILECONNECTIONSTRING = azurerm_storage_account.for_func.primary_connection_string
-    WEBSITE_CONTENTSHARE                     = local.function_name
     FUNCTIONS_WORKER_RUNTIME                 = "dotnet"
     WEBSITE_RUN_FROM_PACKAGE                 = var.function_package_url
     TargetHost                               = regex("^https://(?P<host>[\\d\\w.-]+):443/$", azurerm_cosmosdb_account.main.endpoint).host

--- a/terraform/modules/function_cosmosdb_via_vnet/function.tf
+++ b/terraform/modules/function_cosmosdb_via_vnet/function.tf
@@ -27,7 +27,6 @@ resource "azurerm_function_app" "main" {
   app_settings = {
     AzureWebJobsStorage                      = azurerm_storage_account.for_func.primary_connection_string
     WEBSITE_CONTENTAZUREFILECONNECTIONSTRING = azurerm_storage_account.for_func.primary_connection_string
-    WEBSITE_CONTENTSHARE                     = local.function_name
     WEBSITE_CONTENTOVERVNET                  = 1
     FUNCTIONS_WORKER_RUNTIME                 = "dotnet"
     WEBSITE_RUN_FROM_PACKAGE                 = var.function_package_url


### PR DESCRIPTION
Terraform が Azure Functions の file share のリソース作成及び `WEBSITE_CONTENTSHARE` の設定を自動で行う（ `WEBSITE_CONTENTSHARE` は上書きされる）ため、App Settings の当該設定を削除しました。